### PR TITLE
Workaround #require directive

### DIFF
--- a/src/WPShaderParser.cpp
+++ b/src/WPShaderParser.cpp
@@ -283,6 +283,12 @@ inline std::string Preprocessor(const std::string& in_src, ShaderType type, cons
 
     std::string src = wallpaper::WPShaderParser::PreShaderHeader(in_src, combos, type);
 
+    // workaround #require directive
+    {
+        std::regex re_require("(^|\r?\n)#require (.+)(\r?\n)");
+        src = std::regex_replace(src, re_require, "$1//#require $2$3");
+    }
+
     glslang::TShader::ForbidIncluder includer;
     glslang::TShader                 shader(ToGLSL(type));
     const EShMessages emsg { (EShMessages)(EShMsgDefault | EShMsgSpvRules | EShMsgRelaxedErrors |


### PR DESCRIPTION
The non-standard preprocessor directive "#require ..." appears in e.g. genericimage4.frag, causing the `void main()` after that disappearing. Workaround this by commenting this line out.

This may need to be backported to Plasma 5 branch.

Related: catsout/wallpaper-engine-kde-plugin#378
CC: @tonehrk 