### PR TITLE
Allow VK_SUBOPTIMAL_KHR in VVK_CHECK_ACT

### DIFF
--- a/src/Vulkan/include/vvk/vulkan_wrapper.hpp
+++ b/src/Vulkan/include/vvk/vulkan_wrapper.hpp
@@ -36,7 +36,7 @@ const char* ToString(VkColorSpaceKHR color) noexcept;
 #define VVK_CHECK_ACT(act, f)                                     \
     {                                                             \
         VkResult _res = (f);                                      \
-        if (_res != VK_SUCCESS) {                                 \
+        if (_res != VK_SUCCESS && _res != VK_SUBOPTIMAL_KHR) {    \
             LOG_ERROR("VkResult is \"%s\"", vvk::ToString(_res)); \
             assert(_res == VK_SUCCESS);                           \
             { act; };                                             \

--- a/src/Vulkan/vulkan_wrapper.cpp
+++ b/src/Vulkan/vulkan_wrapper.cpp
@@ -620,7 +620,7 @@ const char* ToString(VkResult result) noexcept {
         X(SUBOPTIMAL_KHR)
 
         default:
-        return "VK_COLOR_SPACE_UNKNOWN";
+        return "VK_RESULT_UNKNOWN";
     }
     #undef X
 }

--- a/src/Vulkan/vulkan_wrapper.cpp
+++ b/src/Vulkan/vulkan_wrapper.cpp
@@ -616,6 +616,8 @@ const char* ToString(VkResult result) noexcept {
         X(ERROR_NATIVE_WINDOW_IN_USE_KHR)
         // Provided by VK_EXT_debug_report
         X(ERROR_VALIDATION_FAILED_EXT)
+        // Provided by VK_KHR_swapchain
+        X(SUBOPTIMAL_KHR)
 
         default:
         return "VK_COLOR_SPACE_UNKNOWN";


### PR DESCRIPTION
VK_SUBOPTIMAL_KHR is considered success,
see https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkAcquireNextImageKHR.html
This is triggered when using standalone scene viewer.

Also corrected name of unknown in `ToString(VkResult)`