### PR TITLE
Fixed several crashing wallpapers for #6

### DIFF
--- a/src/Vulkan/Swapchain.cpp
+++ b/src/Vulkan/Swapchain.cpp
@@ -37,9 +37,14 @@ VkSurfaceFormatKHR chooseSwapSurfaceFormat(std::span<const VkSurfaceFormatKHR> a
 }
 
 VkExtent2D GetSwapChainExtent(VkSurfaceCapabilitiesKHR& surface_capabilities, VkExtent2D ext) {
-    if (surface_capabilities.currentExtent.width == 0) {
-        auto min = surface_capabilities.minImageExtent;
-        auto max = surface_capabilities.maxImageExtent;
+    auto min = surface_capabilities.minImageExtent;
+    auto max = surface_capabilities.maxImageExtent;
+    auto currExt = surface_capabilities.currentExtent;
+
+    if( currExt.width == 0
+        || currExt.width < min.width || currExt.width > max.width
+        || currExt.height < min.height || currExt.height > max.height
+    ){
         if (ext.width < min.width) {
             ext.width = min.width;
         }
@@ -104,7 +109,8 @@ bool Swapchain::Create(Device& device, VkSurfaceKHR surface, VkExtent2D extent, 
     uint32_t image_count = surfaceCapabilities.minImageCount + 1;
     if (surfaceCapabilities.maxImageCount > 0 && image_count > surfaceCapabilities.maxImageCount)
         image_count = surfaceCapabilities.maxImageCount;
-
+    surfaceCapabilities.currentExtent = swap.m_extent;
+    
     swap.m_extent = GetSwapChainExtent(surfaceCapabilities, extent);
 
     swap.m_present_mode                          = VK_PRESENT_MODE_FIFO_KHR;

--- a/src/Vulkan/vulkan_wrapper.cpp
+++ b/src/Vulkan/vulkan_wrapper.cpp
@@ -584,7 +584,7 @@ EnumerateInstanceLayerProperties(const InstanceDispatch& dld) {
 
 // clang-format off
 const char* ToString(VkResult result) noexcept {
-    #define X(str) case VkResult::VK_##str: return "VK_##str";
+    #define X(str) case VkResult::VK_##str: return "VK_" #str;
     switch (result) {
         X(SUCCESS)
         X(NOT_READY)

--- a/src/WPMdlParser.cpp
+++ b/src/WPMdlParser.cpp
@@ -270,6 +270,11 @@ bool WPMdlParser::Parse(std::string_view path, fs::VFS& vfs, WPMdl& mdl) {
                     f.ReadUint8();
                     f.ReadUint8();    
                 }
+                else if(mdl.mdla == 3){
+                    // In MDLA version 3 there is an extra 8-bit zero between animations.
+                    // This will cause the parser to be misaligned moving forward if we don't handle it here.
+                    f.ReadUint8();
+                }
                 else{
                     uint32_t unk_extra_uint = f.ReadUint32();
                     for (uint i = 0; i < unk_extra_uint; i++) {

--- a/src/WPMdlParser.cpp
+++ b/src/WPMdlParser.cpp
@@ -28,6 +28,7 @@ WPPuppet::PlayMode ToPlayMode(std::string_view m) {
 // bytes * size
 constexpr uint32_t singile_vertex  = 4 * (3 + 4 + 4 + 2);
 constexpr uint32_t singile_indices = 2 * 3;
+constexpr uint32_t std_format_vertex_size_herald_value = 0x01800009;
 
 constexpr uint32_t mdat_body_byte_length = 83;
 
@@ -69,6 +70,9 @@ bool WPMdlParser::Parse(std::string_view path, fs::VFS& vfs, WPMdl& mdl) {
         while (curr != alt_format_vertex_size_herald_value){
             curr = f.ReadUint32();
         }
+        curr = f.ReadUint32();
+    }
+    else if(curr == std_format_vertex_size_herald_value){
         curr = f.ReadUint32();
     }
 
@@ -222,6 +226,9 @@ bool WPMdlParser::Parse(std::string_view path, fs::VFS& vfs, WPMdl& mdl) {
                 }
                 f.ReadInt32();
                 anim.name   = f.ReadStr();
+                if(anim.name.empty()){
+                    anim.name = f.ReadStr();
+                }
                 anim.mode   = ToPlayMode(f.ReadStr());
                 anim.fps    = f.ReadFloat();
                 anim.length = f.ReadInt32();

--- a/src/WPPuppet.hpp
+++ b/src/WPPuppet.hpp
@@ -110,7 +110,8 @@ private:
         operator bool() const noexcept { return anim != nullptr; };
     };
 
-    double m_global_blend { 1.0f };
+    double m_global_blend { 1.0 };
+    double m_total_blend { 0.0 };
 
     std::vector<Layer>        m_layers;
     std::shared_ptr<WPPuppet> m_puppet;

--- a/src/WPSceneParser.cpp
+++ b/src/WPSceneParser.cpp
@@ -579,9 +579,10 @@ void ParseImageObj(ParseContext& context, wpscene::WPImageObject& img_obj) {
         puppet = std::make_unique<WPMdl>();
         if (! WPMdlParser::Parse(wpimgobj.puppet, vfs, *puppet)) {
             LOG_ERROR("parse puppet failed: %s", wpimgobj.puppet.c_str());
-            return;
+            puppet = nullptr;
         }
-        if (puppet->puppet->bones.size() == 0){
+        else if (puppet->puppet->bones.size() == 0){
+            LOG_ERROR("puppet has no bones: %s", wpimgobj.puppet.c_str());
             puppet = nullptr;
         }
     }

--- a/src/WPSceneParser.cpp
+++ b/src/WPSceneParser.cpp
@@ -581,6 +581,9 @@ void ParseImageObj(ParseContext& context, wpscene::WPImageObject& img_obj) {
             LOG_ERROR("parse puppet failed: %s", wpimgobj.puppet.c_str());
             return;
         }
+        if (puppet->puppet->bones.size() == 0){
+            puppet = nullptr;
+        }
     }
 
     // wpimgobj.origin[1] = context.ortho_h - wpimgobj.origin[1];
@@ -1149,8 +1152,8 @@ std::shared_ptr<Scene> WPSceneParser::Parse(std::string_view scene_id, const std
 
     for (WPObjectVar& obj : wp_objs) {
         std::visit(visitor::overload {
-                       [&context](wpscene::WPImageObject& obj) {
-                           ParseImageObj(context, obj);
+                       [&context](wpscene::WPImageObject& obj) {                           
+                            ParseImageObj(context, obj);
                        },
                        [&context](wpscene::WPParticleObject& obj) {
                            ParseParticleObj(context, obj);

--- a/src/wpscene/WPImageObject.h
+++ b/src/wpscene/WPImageObject.h
@@ -4,6 +4,9 @@
 #include "WPMaterial.h"
 #include <vector>
 #include "WPPuppet.hpp"
+#include <unordered_set>
+#include <string>
+#include <filesystem>
 
 namespace wallpaper
 {
@@ -34,6 +37,9 @@ public:
 };
 
 class WPImageEffect {
+private:
+    static const std::unordered_set<std::string> BLACKLISTED_WORKSHOP_EFFECTS;
+    bool IsEffectBlacklisted(const std::string& filePath);
 public:
     bool                         FromJson(const nlohmann::json&, fs::VFS& vfs);
     bool                         FromFileJson(const nlohmann::json&, fs::VFS& vfs);


### PR DESCRIPTION
Fixed #6 

Fixed crashes caused by several wallpapers.

This fix builds on top of https://github.com/catsout/wallpaper-scene-renderer/pull/5

Added handling for a new scenario with regard to parsing the vertex size. This fixed the crashing for https://steamcommunity.com/sharedfiles/filedetails/?id=2924727184 but it still doesn't render very well

Added a workshop effects blacklist, and blacklisted [Audio responsive oscilloscope](https://steamcommunity.com/sharedfiles/filedetails/?id=2799421411) as it was causing some tricky Vulkan deadlocking issues. This should fix many wallpapers, but it at least fixed https://steamcommunity.com/sharedfiles/filedetails/?id=2988406607 which no longer crashes and also renders pretty well now otherwise.

Improved handling of MDAT sections during MDL parsing, which fixed crashing in all the following wallpapers (though none of them render particularly well yet)
https://steamcommunity.com/sharedfiles/filedetails/?id=3061226599
https://steamcommunity.com/sharedfiles/filedetails/?id=3167305590
https://steamcommunity.com/sharedfiles/filedetails/?id=3104389443
https://steamcommunity.com/sharedfiles/filedetails/?id=2933898202
