### PR TITLE
Fix deprecated Qt API for Qt 6 compatibility

### DIFF
--- a/qml_helper/SceneBackend.cpp
+++ b/qml_helper/SceneBackend.cpp
@@ -311,12 +311,20 @@ void SceneObject::setAcceptHover(bool value) { setAcceptHoverEvents(value); }
 
 void SceneObject::mousePressEvent(QMouseEvent* event) {}
 void SceneObject::mouseMoveEvent(QMouseEvent* event) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    auto pos = event->position();
+#else
     auto pos = event->localPos();
+#endif
     m_scene->mouseInput(pos.x() / width(), pos.y() / height());
 }
 
 void SceneObject::hoverMoveEvent(QHoverEvent* event) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    auto pos = event->position();
+#else
     auto pos = event->posF();
+#endif
     m_scene->mouseInput(pos.x() / width(), pos.y() / height());
 }
 

--- a/standalone_view/qmlviewer.cpp
+++ b/standalone_view/qmlviewer.cpp
@@ -1,4 +1,5 @@
 #include "SceneBackend.hpp"
+#include <QtGlobal>
 #include <QGuiApplication>
 #include <QtQml>
 #include <QtQuick/QQuickView>
@@ -10,7 +11,9 @@ int main(int argc, char** argv) {
     argparse::ArgumentParser program("scene-viewer");
     setAndParseArg(program, argc, argv);
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
+#endif
     QGuiApplication app(argc, argv);
 
     qmlRegisterType<scenebackend::SceneObject>("scenetest", 1, 0, "SceneViewer");


### PR DESCRIPTION
- SceneBackend.cpp: Use event->position() instead of localPos()/posF()
- qmlviewer.cpp: Wrap AA_DisableHighDpiScaling in Qt version check