### PR TITLE
Fix crash when particle sprite texture has zero frames

### DIFF
--- a/src/WPSceneParser.cpp
+++ b/src/WPSceneParser.cpp
@@ -371,7 +371,7 @@ bool LoadMaterial(fs::VFS& vfs, const wpscene::WPMaterial& wpmat, Scene* pScene,
             }
             if ((pScene->textures.at(name)).isSprite) {
                 material.hasSprite = true;
-                const auto& f1     = texh.spriteAnim.GetCurFrame();
+const auto& f1     = texh.spriteAnim.GetCurFrame();
                 if (wpmat.shader == "genericparticle" || wpmat.shader == "genericropeparticle") {
                     pWPShaderInfo->combos["SPRITESHEET"] = "1";
                     pWPShaderInfo->combos["THICKFORMAT"] = "1";
@@ -985,13 +985,19 @@ void ParseParticleObj(ParseContext& context, wpscene::WPParticleObject& wppartob
         shaderInfo.combos["SPRITESHEETBLEND"] = "1";
     }
 
-    if (! LoadMaterial(vfs,
-                       particle_obj.material,
-                       context.scene.get(),
-                       spNode.get(),
-                       &material,
-                       &svData,
-                       &shaderInfo)) {
+    bool mat_ok = false;
+    try {
+        mat_ok = LoadMaterial(vfs,
+                              particle_obj.material,
+                              context.scene.get(),
+                              spNode.get(),
+                              &material,
+                              &svData,
+                              &shaderInfo);
+    } catch (const std::exception& e) {
+        LOG_ERROR("load particleobj '%s' material exception: %s", wppartobj.name.c_str(), e.what());
+    }
+    if (! mat_ok) {
         LOG_ERROR("load particleobj '%s' material faild", wppartobj.name.c_str());
         return;
     }


### PR DESCRIPTION
## Summary

- `LoadMaterial` calls `GetCurFrame()` on a `SpriteAnimation` without first checking whether any frames were parsed. When the frame list is empty, `at()` throws `std::out_of_range`, which propagates uncaught through `ParseParticleObj` and hits `std::terminate()`, crashing the host process.
- Wraps the `LoadMaterial` call in `ParseParticleObj` with a `try/catch` so any exception from malformed sprite data logs an error and skips the particle object gracefully.

## Reproduction

Any scene wallpaper that uses particle effects with sprite-animated materials where the sprite frame data is absent or unparseable (confirmed with workshop item 2609314607 which uses `particles/presets/lightning1.json`). Selecting such a wallpaper in the KDE plugin crashes plasmashell immediately with SIGABRT via `std::terminate`.

## Stack trace (from coredumpctl)

```
#7  std::__throw_out_of_range_fmt         (libstdc++.so.6)
#8  vector<vector<float>>::_M_range_check (libWallpaperEngineKde.so)
#9  LoadMaterial                           (libWallpaperEngineKde.so)
#10 ParseParticleObj                       (libWallpaperEngineKde.so)
#11 ParseParticleObj                       (libWallpaperEngineKde.so)  ← child particle
```

## Test plan

- [ ] Load a wallpaper with lightning particle effects (e.g. workshop item 2609314607)
- [ ] Confirm host process survives (particles may not render, but no crash)
- [ ] Confirm normal particle wallpapers still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)